### PR TITLE
Make dispatched natively-bubbling event types bubble

### DIFF
--- a/bililiteRange.js
+++ b/bililiteRange.js
@@ -116,7 +116,7 @@ bililiteRange = function(el, debug){
 		// give IE8 a chance. Note that this still fails in IE11, which has has oninput on contenteditable elements but does not 
 		// dispatch input events. See http://connect.microsoft.com/IE/feedback/details/794285/ie10-11-input-event-does-not-fire-on-div-with-contenteditable-set
 		// TODO: revisit this when I have IE11 running on my development machine
-		var inputhack = function() {ret.dispatch({type: 'input'}) };
+		var inputhack = function() {ret.dispatch({type: 'input', bubbles: true}) };
 		ret.listen('keyup', inputhack);
 		ret.listen('cut', inputhack);
 		ret.listen('paste', inputhack);
@@ -163,7 +163,7 @@ Range.prototype = {
 			// only actually select if this element is active!
 			this._nativeSelect(this._nativeRange(b));
 		}
-		this.dispatch({type: 'select'});
+		this.dispatch({type: 'select', bubbles: true});
 		return this; // allow for chaining
 	},
 	text: function(text, select){
@@ -171,7 +171,8 @@ Range.prototype = {
 			var bounds = this.bounds(), el = this._el;
 			// signal the input per DOM 3 input events, http://www.w3.org/TR/DOM-Level-3-Events/#h4_events-inputevents
 			// we add another field, bounds, which are the bounds of the original text before being changed.
-			this.dispatch({type: 'beforeinput', data: text, bounds: bounds});
+			this.dispatch({type: 'beforeinput', bubbles: true,
+			               data: text, bounds: bounds});
 			this._nativeSetText(text, this._nativeRange(bounds));
 			if (select == 'start'){
 				this.bounds ([bounds[0], bounds[0]]);
@@ -180,7 +181,8 @@ Range.prototype = {
 			}else if (select == 'all'){
 				this.bounds ([bounds[0], bounds[0]+text.length]);
 			}
-			this.dispatch({type: 'input', data: text, bounds: bounds});
+			this.dispatch({type: 'input', bubbles: true,
+			               data: text, bounds: bounds});
 			return this; // allow for chaining
 		}else{
 			return this._nativeGetText(this._nativeRange(this.bounds())).replace(/\r/g, ''); // need to correct for IE's CrLf weirdness
@@ -199,7 +201,7 @@ Range.prototype = {
 			if (/^{[^}]*}$/.test(c)) c = c.slice(1,-1);	// deal with unknown {key}s
 			for (var i =0; i < c.length; ++i){
 				var x = c.charCodeAt(i);
-				rng.dispatch({type: 'keypress', keyCode: x, which: x, charCode: x});
+				rng.dispatch({type: 'keypress', bubbles: true, keyCode: x, which: x, charCode: x});
 			}
 			rng.text(c, 'end');
 		}
@@ -241,9 +243,9 @@ Range.prototype = {
 	},
 	all: function(text){
 		if (arguments.length){
-			this.dispatch ({type: 'beforeinput', data: text});
+			this.dispatch ({type: 'beforeinput', bubbles: true, data: text});
 			this._el[this._textProp] = text;
-			this.dispatch ({type: 'input', data: text});
+			this.dispatch ({type: 'input', bubbles: true, data: text});
 			return this;
 		}else{
 			return this._el[this._textProp].replace(/\r/g, ''); // need to correct for IE's CrLf weirdness
@@ -361,7 +363,7 @@ bililiteRange.sendkeys = {
 		var s = rng.data().sendkeysOriginalText;
 		for (var i =0; i < s.length; ++i){
 			var x = s.charCodeAt(i);
-			rng.dispatch({type: 'keypress', keyCode: x, which: x, charCode: x});
+			rng.dispatch({type: 'keypress', bubbles: true, keyCode: x, which: x, charCode: x});
 		}
 		rng.text(s, 'end');
 	},


### PR DESCRIPTION
According to [1], 'input', 'beforeinput', 'keypress' and 'select'
bubble.

This patch allows my jQuery delegated event handlers that
were triggering on native 'input' events to also trigger on
bililiteRange input events.[2]

[1]
http://www.w3.org/TR/DOM-Level-3-Events/#h-event-types-list
http://www.w3.org/TR/DOM-Level-3-Events/#legacy-event-types
(MDN disagrees about the 'select' event bubbling, but I guess
W3C is a more canonical source than an MDN article that says
it could use a technical review.
https://developer.mozilla.org/en-US/docs/Web/Events/select
)

[2] for an explanation, see http://stackoverflow.com/q/26423742