### PR TITLE
make findBack (like fwd) let result[1]=bounds[0]

### DIFF
--- a/bililiteRange.util.js
+++ b/bililiteRange.util.js
@@ -71,14 +71,16 @@ bililiteRange.extend({
 		var bounds = this.bounds();
 		if (!backwards){
 			var findprimitive = 'findprimitive';
-			var initialbounds = [bounds[0], Number.MAX_VALUE]
+			var initialbounds = [bounds[0], Number.MAX_VALUE];
+			var fallbackbounds = [bounds[0]+1, Number.MAX_VALUE];
 		}else{
 			findprimitive = 'findprimitiveback';
-			initialbounds = [0, bounds[0]-1];
+			initialbounds = [0, bounds[0]];
+			fallbackbounds = [0, bounds[0]-1];
 		}
 		var match = this[findprimitive](re, initialbounds);
 		if (matchIs(match, bounds)){ // if the match is exactly the current string, it doesn't count
-			match = this[findprimitive](re, [bounds[0]+1, Number.MAX_VALUE]);
+			match = this[findprimitive](re, fallbackbounds);
 		}
 		if (!match && !nowrap) match = this[findprimitive](re, [0, Number.MAX_VALUE]);
 		if (matchIs(match, bounds)) match = false; // again, even with wrapping, don't find the identical segment


### PR DESCRIPTION
For example, given "foo| bar", where | is the range's position, findBack(/foo/) should be able to find foo.