### PR TITLE
Added Support for IE 9 and IE 11 using `textinput` event

### DIFF
--- a/bililiteRange.js
+++ b/bililiteRange.js
@@ -116,10 +116,11 @@ bililiteRange = function(el, debug){
 		// give IE8 a chance. Note that this still fails in IE11, which has has oninput on contenteditable elements but does not 
 		// dispatch input events. See http://connect.microsoft.com/IE/feedback/details/794285/ie10-11-input-event-does-not-fire-on-div-with-contenteditable-set
 		// TODO: revisit this when I have IE11 running on my development machine
+		// TODO: FIXED
 		
 		var inputhack = function() {ret.dispatch({type: 'input', bubbles: true}) };
 		
-		if(typeof window.setTimeout == 'object'){ /* IE 8 see `setTimeout` as an `object` and not a `function` */
+		if(typeof window.setTimeout == 'object'){ /* IE 8 sees `setTimeout` as an `object` and not a `function` */
 			
 			ret.listen('keyup', inputhack);
 			ret.listen('cut', inputhack);
@@ -127,8 +128,21 @@ bililiteRange = function(el, debug){
 			ret.listen('drop', inputhack);
 			el.oninput = 'patched';
 			
-		}else{
-			ret.listen('textinput', iinputhack); /* IE 9 doesn't support `input` event but supports `textinput` */
+		}
+	}else{
+		
+		/* 
+			IE9/IE11 supports the `textinput` event (even on contenteditable elements)
+
+			See http://help.dottoro.com/ljhiwalm.php 
+		*/
+		
+		/* Detect IE 9/11, See: https://stackoverflow.com/questions/21825157/internet-explorer-11-detection  */
+		
+		if((!(window.FileReader) || !!window.MSInputMethodContext) && !!document.documentMode){ 
+			
+			ret.listen('textinput', function(){ ret.dispatch({type: 'input', bubbles: true}); });
+			
 		}
 	}
 	return ret;

--- a/bililiteRange.js
+++ b/bililiteRange.js
@@ -116,12 +116,20 @@ bililiteRange = function(el, debug){
 		// give IE8 a chance. Note that this still fails in IE11, which has has oninput on contenteditable elements but does not 
 		// dispatch input events. See http://connect.microsoft.com/IE/feedback/details/794285/ie10-11-input-event-does-not-fire-on-div-with-contenteditable-set
 		// TODO: revisit this when I have IE11 running on my development machine
+		
 		var inputhack = function() {ret.dispatch({type: 'input', bubbles: true}) };
-		ret.listen('keyup', inputhack);
-		ret.listen('cut', inputhack);
-		ret.listen('paste', inputhack);
-		ret.listen('drop', inputhack);
-		el.oninput = 'patched';
+		
+		if(typeof window.setTimeout == 'object'){ /* IE 8 see `setTimeout` as an `object` and not a `function` */
+			
+			ret.listen('keyup', inputhack);
+			ret.listen('cut', inputhack);
+			ret.listen('paste', inputhack);
+			ret.listen('drop', inputhack);
+			el.oninput = 'patched';
+			
+		}else{
+			ret.listen('textinput', iinputhack); /* IE 9 doesn't support `input` event but supports `textinput` */
+		}
 	}
 	return ret;
 }

--- a/bililiteRange.undo.js
+++ b/bililiteRange.undo.js
@@ -76,7 +76,7 @@ function restore (state, dir, rng){
 }
 
 function setuplisteners (rng){
-	rng.listen('input', function(){
+	var _callback = function(){
 		var state = getundostate(rng), el = rng.element(), lastevent = state.lastevent;
 		delete state.lastevent;
 		switch (lastevent){
@@ -88,7 +88,11 @@ function setuplisteners (rng){
 				if (state.penultimateevent == 'keypress') rng.data().undos = state.undo;
 		}
 		(new undostate(rng)).penultimateevent = lastevent; // record so we can check for keypress sequences
-	}).listen('keypress', function(evt){
+	};
+	
+	rng.listen('input', _callback) /* `input` event is for IE >= 10 */
+		.listen('textinput', _callback) /* `textinput` event is for IE 9 */
+		.listen('keypress', function(evt){
 		// key presses replace each other, which means that undo will undo all of them, unless the previous event was not a keypress (meaning we are starting a
 		// new series of typing) or we type a carriage return, which starts a new series of typing, or the new keypress is in a different place than the old one
 		if (evt.which < 32) return; // nonprinting characters; Firefox tends to send them all. We want them all undone individually


### PR DESCRIPTION
I read up all of your code and discovered you had some *TODOs* pending. So, i fixed up for IE 9 and IE 11 to support contenteditable elements.